### PR TITLE
refactor: 정책 리스트 조회 API 빈 파라미터 처리 개선

### DIFF
--- a/src/main/java/com/example/withpeace/controller/YouthPolicyController.java
+++ b/src/main/java/com/example/withpeace/controller/YouthPolicyController.java
@@ -30,8 +30,8 @@ public class YouthPolicyController {
 
     // 정책 리스트 조회
     @GetMapping("")
-    public ResponseDto<?> getPolicyList(@RequestParam(required = false) String region,
-                                        @RequestParam(required = false) String classification,
+    public ResponseDto<?> getPolicyList(@RequestParam(defaultValue = "") String region,
+                                        @RequestParam(defaultValue = "") String classification,
                                         @RequestParam(defaultValue = "1") @Valid @NotNull @Min(1) Integer pageIndex,
                                         @RequestParam(defaultValue = "10") @Valid @NotNull @Min(10) Integer display) {
         List<PolicyListResponseDto> policyList = youthPolicyService.getPolicyList(

--- a/src/main/java/com/example/withpeace/service/YouthPolicyService.java
+++ b/src/main/java/com/example/withpeace/service/YouthPolicyService.java
@@ -11,6 +11,7 @@ import com.example.withpeace.repository.YouthPolicyRepository;
 import com.example.withpeace.type.EPolicyClassification;
 import com.example.withpeace.type.EPolicyRegion;
 import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import io.micrometer.common.util.StringUtils;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -140,14 +141,14 @@ public class YouthPolicyService {
     @Transactional
     public List<PolicyListResponseDto> getPolicyList(String region, String classification, Integer pageIndex, Integer display) {
         List<EPolicyRegion> regionList = null;
-        if (region != null) {
+        if (StringUtils.isNotBlank(region)) { // null, 빈 문자열, 공백만 있는 문자열을 모두 처리
             regionList = Arrays.stream(region.split(","))
                     .map(EPolicyRegion::fromCode)
                     .collect(Collectors.toList());
         }
 
         List<EPolicyClassification> classificationList = null;
-        if (classification != null) {
+        if (StringUtils.isNotBlank(classification)) {
             classificationList = Arrays.stream(classification.split(","))
                     .map(EPolicyClassification::fromCode)
                     .collect(Collectors.toList());


### PR DESCRIPTION
## 관련 이슈번호
#42
 
<br/> 

## 작업 사항
- @RequestParam의 `required = false`을 `defaultValue = ""`로 변경

<br/>

## 기타 사항
<br/>