### PR TITLE
feat: Docker 컨테이너 및 배포 환경 타임존 KST로 설정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -62,6 +62,8 @@ jobs:
             sudo docker stop springboot
             sudo docker rm -f springboot
             sudo docker pull ${{secrets.DOCKER_REPOSITORY}}
-            sudo docker run -d -p 8080:8080 --net=host --name springboot ${{secrets.DOCKER_REPOSITORY}}
+            sudo docker run -d -p 8080:8080 --net=host --name springboot \
+              -e TZ=Asia/Seoul \
+              ${{secrets.DOCKER_REPOSITORY}}
             sudo docker image prune -f
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # Start a new stage
 FROM openjdk:17-jdk-alpine
+
+# Set timezone to Asiz/Seoul
+ENV TZ=Asia/Seoul
+RUN apk add --no-cache tzdata && \
+    ln -sf /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo "Asia/Seoul" > /etc/timezone
+
 WORKDIR /app
 ARG JAR_FILE=./build/libs
 COPY ${JAR_FILE}/*.jar app.jar


### PR DESCRIPTION
## 관련 이슈번호
 
<br/> 

## 작업 사항
- 밸런스게임 조회 시 "오늘의 밸런스게임"의 시간 문제 해결
- Dockerfile에서 기본 타임존을 `Asia/Seoul` 로 설정
- CI/CD에서 docker run 실행 시 `-e TZ=Asia/Seoul` 옵션 추가

<br/>

## 기타 사항

<br/>