### PR TITLE
fix: staging 배포 시 SSH 사용자명을 lpromotion00으로 변경

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -59,7 +59,7 @@ jobs:
         uses: appleboy/ssh-action@master
         with:
           host: ${{secrets.STAGING_HOST}}
-          username: root
+          username: lpromotion00
           key: ${{ secrets.STAGING_PRIVATE_KEY }}
           envs: GITHUB_SHA
           script: |


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- root 사용자 인증 실패로 인해 접속 불가 문제 발생
- staging 서버에 등록된 SSH 키와 일치하는 사용자명으로 수정

<br/>

## 기타 사항