### PR TITLE
fix(ci): staging 서버를 prod와 동일하게 구성

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,11 +70,11 @@ jobs:
             export OAUTH_CLIENT_SECRET=${{secrets.OAUTH_CLIENT_SECRET}}
             
             sudo docker ps
-            sudo docker stop springboot-staging
-            sudo docker rm -f springboot-staging
+            sudo docker stop springboot
+            sudo docker rm -f springboot
             sudo docker pull ${{secrets.DOCKER_REPOSITORY}}
             
-            sudo docker run -d -p 8081:8080 --name springboot-staging \
+            sudo docker run -d -p 8081:8080 --net=host --name springboot \
             -v /mnt/data/LegalDongCode_List.txt:/app/data/LegalDongCode_List.txt \
             -e TZ=Asia/Seoul \
             -e DB_USERNAME=${DB_USERNAME} \


### PR DESCRIPTION
## 관련 이슈번호
없음

<br/>

## 작업 사항
- staging 배포 시 컨테이너명을 `springboot-staging` → `springboot`로 통일
- DB 연결 문제 해결을 위해 `--net=host` 옵션 복구

<br/>

## 기타 사항
