### PR TITLE
fix(ci): staging 배포 시 latest 이미지가 아닌 staging 태그 이미지 사용

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -72,7 +72,7 @@ jobs:
             sudo docker ps
             sudo docker stop springboot
             sudo docker rm -f springboot
-            sudo docker pull ${{secrets.DOCKER_REPOSITORY}}
+            sudo docker pull ${{secrets.DOCKER_REPOSITORY}}:staging
             
             sudo docker run -d -p 8081:8080 --net=host --name springboot \
             -v /mnt/data/LegalDongCode_List.txt:/app/data/LegalDongCode_List.txt \
@@ -82,7 +82,7 @@ jobs:
             -e JWT_SECRET=${JWT_SECRET} \
             -e OAUTH_CLIENT_ID=${OAUTH_CLIENT_ID} \
             -e OAUTH_CLIENT_SECRET=${OAUTH_CLIENT_SECRET} \
-            ${{secrets.DOCKER_REPOSITORY}}
+            ${{secrets.DOCKER_REPOSITORY}}:staging
             
             sudo docker image prune -f
 


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- staging 서버에서 `docker pull`과 `docker run` 시 staging 태그(:staging) 명시
- dev 이미지가 잘못 배포되는 문제 해결

<br/>

## 기타 사항
