### PR TITLE
fix(cicd): Dockerfile과 CI 설정 수정으로 staging/prod 프로필 분기 해결

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -114,6 +114,7 @@ jobs:
             sudo docker run -d -p 8080:8080 --net=host --name springboot \
             -v /mnt/data/LegalDongCode_List.txt:/app/data/LegalDongCode_List.txt \
             -e TZ=Asia/Seoul \
+            -e SPRING_PROFILES_ACTIVE=dev \ 
             -e DB_USERNAME=${DB_USERNAME} \
             -e DB_PASSWORD=${DB_PASSWORD} \
             -e JWT_SECRET=${JWT_SECRET} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN apk add --no-cache tzdata && \
 WORKDIR /app
 ARG JAR_FILE=./build/libs
 COPY ${JAR_FILE}/*.jar app.jar
-ENTRYPOINT ["java", "-jar","./app.jar", "--spring.profiles.active=dev"]
+ENTRYPOINT ["java", "-jar", "./app.jar", "-Dspring.profiles.active=${SPRING_PROFILES_ACTIVE:-local}"]


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- Dockerfile 내 ENTRYPOINT 수정: --spring.profiles.active 하드코딩 제거 
  → 환경변수 SPRING_PROFILES_ACTIVE 사용하도록 수정
- staging, prod 배포 시 docker run에 SPRING_PROFILES_ACTIVE 환경변수 설정 추가
- staging → staging 태그로 빌드 및 배포
- prod → latest (기본) 태그로 빌드 및 배포

<br/>

## 기타 사항
