### PR TITLE
fix(cicd): staging 서버에서 nginx 연동을 위한 컨테이너 포트 수정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -74,7 +74,7 @@ jobs:
             sudo docker rm -f springboot
             sudo docker pull ${{secrets.DOCKER_REPOSITORY}}:staging
             
-            sudo docker run -d -p 8081:8080 --net=host --name springboot \
+            sudo docker run -d -p 8080:8080 --net=host --name springboot \
             -v /mnt/data/LegalDongCode_List.txt:/app/data/LegalDongCode_List.txt \
             -e TZ=Asia/Seoul \
             -e SPRING_PROFILES_ACTIVE=staging \


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- docker run 시 외부 포트를 8081 → 8080으로 변경

<br/>

## 기타 사항
