### PR TITLE
fix(ci): 포트 충돌 방지를 위해 staging 서버 구성 변경

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -74,7 +74,7 @@ jobs:
             sudo docker rm -f springboot
             sudo docker pull ${{secrets.DOCKER_REPOSITORY}}:staging
             
-            sudo docker run -d -p 8080:8080 --net=host --name springboot \
+            sudo docker run -d -p 8081:8080 --net=host --name springboot \
             -v /mnt/data/LegalDongCode_List.txt:/app/data/LegalDongCode_List.txt \
             -e TZ=Asia/Seoul \
             -e SPRING_PROFILES_ACTIVE=staging \

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -1,3 +1,5 @@
+server:
+  port: 8081
 spring:
   servlet:
     multipart:


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- application-staging.yml에 server.port=8081 설정 추가
- staging 배포 시 docker run 포트를 8081:8080으로 다시 변경

<br/>

## 기타 사항
