### PR TITLE
fix: Redis 장애 대응 로직 개선 및 타임아웃/로그 레벨 설정 추가

### DIFF
--- a/src/main/java/com/example/withpeace/config/RedisConfig.java
+++ b/src/main/java/com/example/withpeace/config/RedisConfig.java
@@ -1,16 +1,16 @@
 package com.example.withpeace.config;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 /**
  * Redis 설정 클래스
@@ -25,12 +25,24 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int port;
 
+    @Value("${spring.data.redis.timeout}")
+    private Duration timeout;
+
     /**
      * Redis 연결을 위한 LettuceConnectionFactory 빈 생성
      */
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory(host, port);
+        // 1. Redis 서버 정보 설정
+        RedisStandaloneConfiguration standaloneConfiguration = new RedisStandaloneConfiguration(host, port);
+
+        // 2. Lettuce 클라이언트 설정 (명령 타임아웃만 적용)
+        LettuceClientConfiguration clientConfiguration = LettuceClientConfiguration.builder()
+                .commandTimeout(timeout)       // Redis 명령 타임아웃 적용
+                .build();
+
+        // 3. LettuceConnectionFactory 생성
+        return new LettuceConnectionFactory(standaloneConfiguration, clientConfiguration);
     }
 
     /**

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -61,6 +61,12 @@ spring:
           location: classpath:with-peace-801b6-89c6377f475e.json
         project-id: "with-peace-801b6"
         bucket: "cheong-ha-bucket"
+  # Redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 500ms # Redis 명령 실행에 대한 타임아웃 (0.5초)
 
 # Hibernate SQL 바인딩 로그 활성화
 # logging:
@@ -75,6 +81,7 @@ logging:
   level:
     org.springframework.transaction: WARN
     org.springframework.orm.jpa: WARN
+    io.lettuce.core.protocol.ConnectionWatchdog: ERROR
 
 client:
   provider:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -66,6 +66,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      timeout: 500ms # Redis 명령 실행에 대한 타임아웃 (0.5초)
 
 #logging:
 #  level:
@@ -77,6 +78,7 @@ logging:
     org.springframework.orm.jpa: WARN
     org.hibernate.SQL: debug
     org.hibernate.type.descriptor.sql: trace  # 파라미터까지 확인 가능
+    io.lettuce.core.protocol.ConnectionWatchdog: ERROR
 
 
 client:

--- a/src/main/resources/application-staging.yml
+++ b/src/main/resources/application-staging.yml
@@ -68,6 +68,7 @@ spring:
     redis:
       host: localhost
       port: 6379
+      timeout: 500ms # Redis 명령 실행에 대한 타임아웃 (0.5초)
 
 # Hibernate SQL 바인딩 로그 활성화
 # logging:
@@ -82,6 +83,7 @@ logging:
   level:
     org.springframework.transaction: WARN
     org.springframework.orm.jpa: WARN
+    io.lettuce.core.protocol.ConnectionWatchdog: ERROR
 
 client:
   provider:


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- Redis 연결 예외 발생 시 캐시 조회 및 저장 로직 try-catch로 감싸 fallback 동작 보장
- application.yml에 Redis 실행 타임아웃(timeout) 설정 추가
- RedisConfig에서 LettuceConnectionFactory에 타임아웃 설정 적용
- Redis 중단 시 과도한 로그 출력 방지를 위해 ConnectionWatchdog 로그 레벨 ERROR로 조정

<br/>

## 기타 사항
