### PR TITLE
fix(ci): CI/CD 배포 오류 수정: build.yml 완료 후에만 배포 워크플로 트리거되도록 수정

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,15 +10,6 @@ on:
       - completed # build.yml이 완료되었을 때 트리거
     branches:
       - prod # prod 브랜치에서 build.yml이 성공했을 때만 실행
-  push:
-    branches:
-      - prod # prod 브랜치에 직접 푸시될 때도 실행 (선택 사항, workflow_run 대신 사용 가능)
-#  workflow_dispatch: # 선택 사항: 수동으로 워크플로를 실행할 수 있도록 하려면 주석 해제
-#   inputs:
-#     reason:
-#       description: 'Reason for manual deployment'
-#       required: false
-#       default: 'Manual trigger'
 
 permissions:
   contents: read # 저장소 콘텐츠 읽기 권한

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -10,15 +10,6 @@ on:
       - completed # build.yml이 완료되었을 때 트리거
     branches:
       - staging # staging 브랜치에서 build.yml이 성공했을 때만 실행
-  push:
-    branches:
-      - staging # staging 브랜치에 직접 푸시될 때도 실행 (선택 사항, workflow_run 대신 사용 가능)
-#  workflow_dispatch: # 선택 사항: 수동으로 워크플로를 실행할 수 있도록 하려면 주석 해제
-#   inputs:
-#     reason:
-#       description: 'Reason for manual deployment'
-#       required: false
-#       default: 'Manual trigger'
 
 permissions:
   contents: read # 저장소 콘텐츠 읽기 권한


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- `deploy-prod.yml` 및 `deploy-staging.yml`의 `on:` 트리거에서 `push` 이벤트 제거
- `workflow_run` 조건만 사용하여, `build.yml`이 성공적으로 완료된 이후에만 배포 워크플로가 실행되도록 수정

<br/>

## 기타 사항