### PR TITLE
fix(cd): CD 워크플로 수정: cross-workflow 아티팩트 다운로드 오류 해결

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           name: spring-app-jar # build.yml에서 업로드한 아티팩트 이름
           path: . # 현재 워크플로의 루트 디렉터리에 다운로드
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.TOKEN_GITHUB_ACTIONS }}
 
       - name: Prepare JAR for Docker Build # 다운로드된 JAR 파일을 Dockerfile에서 쉽게 참조하도록 준비
         run: mv spring-app-jar/build/libs/*.jar app.jar

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -33,6 +33,8 @@ jobs:
         with:
           name: spring-app-jar # build.yml에서 업로드한 아티팩트 이름
           path: . # 현재 워크플로의 루트 디렉터리에 다운로드
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.TOKEN_GITHUB_ACTIONS }}
 
       - name: Prepare JAR for Docker Build # 다운로드된 JAR 파일을 Dockerfile에서 쉽게 참조하도록 준비
         run: mv spring-app-jar/build/libs/*.jar app.jar


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- `download-artifact@v4` 사용 시, cross-workflow 다운로드를 위한 `run-id`, `github-token` 입력 추가

<br/>

## 기타 사항
- [Cross-run (or repository) downloads](https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/#cross-run-or-repository-downloads)