### PR TITLE
fix(cd): 아티팩트 다운로드 경로 수정

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -36,11 +36,8 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.TOKEN_GITHUB_ACTIONS }}
 
-      - name: Display structure of downloaded files # 다운로드한 JAR 아티팩트의 디렉터리 구조 확인
-        run: ls -R
-
       - name: Prepare JAR for Docker Build # 다운로드된 JAR 파일을 Dockerfile에서 쉽게 참조하도록 준비
-        run: mv build/libs/*.jar app.jar # "Display structure of downloaded files" 결과에 따라 변경 예정
+        run: mv *.jar app.jar
 
       - name: Docker Login # Docker Hub에 인증
         run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_TOKEN}}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -36,11 +36,8 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.TOKEN_GITHUB_ACTIONS }}
 
-      - name: Display structure of downloaded files # 다운로드한 JAR 아티팩트의 디렉터리 구조 확인
-        run: ls -R
-
       - name: Prepare JAR for Docker Build # 다운로드된 JAR 파일을 Dockerfile에서 쉽게 참조하도록 준비
-        run: mv build/libs/*.jar app.jar # "Display structure of downloaded files" 결과에 따라 변경 예정
+        run: mv *.jar app.jar
 
       - name: Docker Login # Docker Hub에 인증
         run: docker login -u ${{secrets.DOCKER_USER}} -p ${{secrets.DOCKER_TOKEN}}


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- `build.yml`에서 `path: build/libs/*.jar`로 업로드된 아티팩트가 다운로드 시 워크플로 러너의 작업 디렉토리 루트에 직접 `.jar` 파일 형태로 압축 해제되는 것을 확인
- 기존 `mv spring-app-jar/*.jar` 명령을 `mv *.jar app.jar`로 수정하여 정확히 이동되도록 반영

<br/>

## 기타 사항
- `Verify downloaded artifact structure` 스텝을 통해 정확한 위치 파악 후 `mv` 경로 확정 예정