### PR TITLE
feat: 조회 기반 기중치 계산을 위해 UserInteraction에 count 필드 도입

### DIFF
--- a/src/main/java/com/example/withpeace/domain/UserInteraction.java
+++ b/src/main/java/com/example/withpeace/domain/UserInteraction.java
@@ -43,6 +43,9 @@ public class UserInteraction {
     @Column(name = "action_type", nullable = false)
     @Enumerated(EnumType.STRING)
     private EActionType actionType;
+    
+    @Column(name = "count", nullable = false)
+    private int count = 1;
 
     @Column(name = "action_time", nullable = false)
     private LocalDateTime actionTime;
@@ -51,6 +54,7 @@ public class UserInteraction {
     public UserInteraction(User user, Policy policy, EActionType actionType) {
         this.user = user;
         this.policy = policy;
+        this.count = 1; // 최초 1로 초기화
         this.actionType = actionType;
         this.actionTime = LocalDateTime.now();
     }

--- a/src/main/java/com/example/withpeace/repository/UserInteractionRepository.java
+++ b/src/main/java/com/example/withpeace/repository/UserInteractionRepository.java
@@ -15,9 +15,13 @@ public interface UserInteractionRepository extends JpaRepository<UserInteraction
 
     // 사용자 조회 기록 저장 (조회 기록이 없으면 INSERT, 있으면 UPDATE)
     @Modifying
-    @Query(value = "INSERT INTO user_interactions (user_id, policy_id, action_type, action_time) " +
-            "VALUES (:userId, :policyId, :actionType, NOW())" +
-            "ON DUPLICATE KEY UPDATE action_time = NOW()", nativeQuery = true)
+    @Query(value = """
+        INSERT INTO user_interactions (user_id, policy_id, action_type, count, action_time)
+        VALUES (:userId, :policyId, :actionType, 1, NOW())
+        ON DUPLICATE KEY UPDATE
+            count = IF(action_type = 'VIEW', count + 1, count),
+            action_time = NOW()
+    """, nativeQuery = true)
     void upsertUserInteraction(Long userId, String policyId, String actionType);
 
     List<UserInteraction> findAllByUserOrderByActionTimeDesc(User user);

--- a/src/main/java/com/example/withpeace/repository/ViewPolicyRepository.java
+++ b/src/main/java/com/example/withpeace/repository/ViewPolicyRepository.java
@@ -9,16 +9,13 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ViewPolicyRepository extends JpaRepository<ViewPolicy, Long> {
 
-    // 조회수가 존재하면 증가시키는 UPDATE 쿼리 (반환값: 업데이트된 행 개수)
+    // 정책의 조회 기록이 없으면 INSERT, 있으면 UPDATE
     @Modifying
-    @Query(value = "UPDATE view_policies SET view_count = view_count + 1 " +
-            "WHERE policy_id = :policyId", nativeQuery = true)
-    int updateViewCount(String policyId);
-
-    // 조회수가 없을 경우 새로운 조회수 INSERT
-    @Modifying
-    @Query(value = "INSERT INTO view_policies (policy_id, view_count) " +
-            "VALUES (:policyId, 1)", nativeQuery = true)
-    void insertViewCount(String policyId);
+    @Query(value = """
+        INSERT INTO view_policies (policy_id, view_count)
+        VALUES (:policyId, 1)
+        ON DUPLICATE KEY UPDATE view_count = view_count + 1
+    """, nativeQuery = true)
+    void upsertViewCount(String policyId);
 
 }

--- a/src/main/java/com/example/withpeace/service/PolicyService.java
+++ b/src/main/java/com/example/withpeace/service/PolicyService.java
@@ -276,10 +276,8 @@ public class PolicyService {
         // 사용자가 해당 정책을 찜했는지 여부 확인
         boolean isFavorite = favoritePolicyRepository.existsByUserIdAndPolicyId(userId, policyId);
         
-        // 정책 조회수 증가 - 조회수가 존재하면 UPDATE, 존재하지 않으면 INSERT
-        if (viewPolicyRepository.updateViewCount(policyId) == 0) {
-            viewPolicyRepository.insertViewCount(policyId);
-        }
+        // 정책 조회수 증가 - 조회 기록이 없으면 INSERT, 있으면 UPDATE
+        viewPolicyRepository.upsertViewCount(policyId);
 
         // 사용자 조회 기록 저장 - 조회 기록이 없으면 INSERT, 있으면 UPDATE
         userInteractionRepository.upsertUserInteraction(userId, policyId, EActionType.VIEW.name());
@@ -397,6 +395,7 @@ public class PolicyService {
         for(UserInteraction interaction : interactions) {
             String policyId = interaction.getPolicy().getId();
             EActionType actionType = interaction.getActionType();
+            int count = interaction.getCount();
             LocalDateTime actionTime = interaction.getActionTime();
 
             // 해당 정책의 현재 가중치 가져오기
@@ -405,7 +404,7 @@ public class PolicyService {
 
             // 상호작용 타입별 가중치 추가
             switch (actionType) {
-                case VIEW -> weight += 1; // 조회 -> +1점
+                case VIEW -> weight += count; // 조회 -> +(count*1)점
                 case FAVORITE -> weight +=3; // 찜하기 -> +3점
             }
 


### PR DESCRIPTION
## 관련 이슈번호

<br/>

## 작업 사항
- UserInteraction 엔티티에 count 필드 추가하여 조회수 누적 가능하도록 개선
- VIEW 타입의 상호작용 발생 시 count 값을 증가시키도록 upsert 쿼리 수정
- 추천 가중치 계산 로직에서 count 값을 반영
- ViewPolicy 조회수 로직도 upsert 방식으로 전환하여 분기 로직 제거 및 쿼리 최적화

<br/>

## 기타 사항
